### PR TITLE
Fix `npm install` and `gulp dmg` on node v0.12

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ var packager = require('electron-packager');
 var preprocessify = require('preprocessify');
 
 function compile(debug) {
-  browserify({ entries: ['src/main.js'], debug })
+  browserify({ entries: ['src/main.js'], debug: debug })
     .transform(preprocessify({"DEBUG": debug }))
     .transform(babelify, {
       presets: ['stage-0', 'es2015', 'react']

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "redux-actions": "^0.9.0",
     "redux-localstorage": "^0.4.0",
     "redux-promise": "^0.5.0",
-    "tumblr": "git@github.com:mzp/node-tumblr.git"
+    "tumblr": "mzp/node-tumblr"
   }
 }


### PR DESCRIPTION
on node v0.12.0, `npm instlal` and `npm run gulp dmg` failed.

```
npm ERR! Darwin 14.5.0
npm ERR! node v0.12.0
npm ERR! npm  v2.5.1
npm ERR! code ENOENT
npm ERR! errno -2

npm ERR! enoent ENOENT, open '.../tumblotte/git@github.com:mzp/node-tumblr.git'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent
```

```
> gulp dmg

.../tumblotte/gulpfile.js:14
  browserify({ entries: ['src/main.js'], debug })
                                               ^
SyntaxError: Unexpected token }
    at exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:443:25)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
```
